### PR TITLE
fix: Display compilation error messages

### DIFF
--- a/api/Controllers/TestsController.cs
+++ b/api/Controllers/TestsController.cs
@@ -67,7 +67,8 @@ public class TestsController(ITestsRepository testsRepository, TestExecutionServ
         {
             using var socket = await HttpContext.WebSockets.AcceptWebSocketAsync();
 
-            return await _testExecutionService.RunTestAsync(socket, fileName, userId);
+            await _testExecutionService.RunTestAsync(socket, fileName, userId);
+            return new EmptyResult();
         }
 
         return BadRequest("This should be a WebSocket connection");
@@ -90,7 +91,8 @@ public class TestsController(ITestsRepository testsRepository, TestExecutionServ
         {
             using var socket = await HttpContext.WebSockets.AcceptWebSocketAsync();
 
-            return await _testExecutionService.RunCompiledTestAsync(socket, userId, runId);
+            await _testExecutionService.RunCompiledTestAsync(socket, userId, runId);
+            return new EmptyResult();
         }
 
         return BadRequest("This should be a WebSocket connection");


### PR DESCRIPTION
## Description

To comply with the change in https://github.com/Ghaadyy/restricted-nl/pull/9 and to display meaningful error messages, we changed the `Parse` method signature in `Parser.cs` to accommodate with changes.
The changes include:
- Extracting the pointers and converting them to correct string error messages.
- Fixing the HTTP response to return an `EmptyResult` instead of a specific `IActionResult` to prevent from rewriting the response since it has been already handled with the websocket connection.