### PR TITLE
fix: Handle graceful switching between UI and code editors

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -67,10 +67,39 @@ function Dashboard({ checks, rerunHandler, fileName }: Props) {
 
   const [testRuns, setTestRuns] = useState<TestRun[]>([]);
 
+  function handleEditorSwitch(checked: boolean) {
+    if (checked) {
+      setCode(generateCode(tests));
+      setIsCode(checked);
+    } else {
+      const [parsedTests, status] = parseCode(code);
+      if (!status) {
+        toast({
+          title: "Test contains syntax errors!",
+          variant: "destructive",
+          description:
+            "Please fix these errors before switching to the UI editor.",
+        });
+        setIsCode(true);
+      } else {
+        setTests(parsedTests);
+        setIsCode(checked);
+      }
+    }
+  }
+
   useEffect(() => {
     openDocument(fileName, ({ content }) => {
       setCode(content);
-      setTests(() => parseCode(content));
+      setTests(() => {
+        const [parsedTests, status] = parseCode(content);
+        if (!status)
+          toast({
+            title: "Test contains syntax errors!",
+          });
+
+        return parsedTests;
+      });
       toast({
         title: "File opened successfully",
       });
@@ -88,11 +117,7 @@ function Dashboard({ checks, rerunHandler, fileName }: Props) {
           <Switch
             id="code-toggle"
             checked={isCode}
-            onCheckedChange={(checked) => {
-              if (checked) setCode(generateCode(tests));
-              else setTests(parseCode(code));
-              setIsCode(checked);
-            }}
+            onCheckedChange={handleEditorSwitch}
           />
           <Label htmlFor="code-toggle">
             {isCode ? "Use visual editor" : "Use code editor"}

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -63,14 +63,14 @@ async function getTestRuns(
 function Dashboard({ checks, rerunHandler, fileName }: Props) {
   const { code, setCode } = useContext(MainContext);
   const [tests, setTests] = useState<Test[]>([]);
-  const [isCode, setIsCode] = useState<boolean>(true);
+  const [isCode, setIsCode] = useState<boolean>(false);
 
   const [testRuns, setTestRuns] = useState<TestRun[]>([]);
 
   useEffect(() => {
     openDocument(fileName, ({ content }) => {
       setCode(content);
-      setTests(parseCode(content));
+      setTests(() => parseCode(content));
       toast({
         title: "File opened successfully",
       });
@@ -115,7 +115,7 @@ function Dashboard({ checks, rerunHandler, fileName }: Props) {
             beforeMount={setupEditor}
           />
         ) : (
-          <TestCreator defaultTests={tests} onChange={setTests} />
+          <TestCreator tests={tests} setTests={setTests} />
         )}
       </ResizablePanel>
       <ResizableHandle withHandle />

--- a/client/src/components/TestCreator.tsx
+++ b/client/src/components/TestCreator.tsx
@@ -16,13 +16,12 @@ import { Input } from "@/shadcn/components/ui/input";
 import { useToast } from "@/shadcn/hooks/use-toast";
 
 function TestCreator({
-  defaultTests,
-  onChange,
+  tests,
+  setTests,
 }: {
-  onChange: (tests: Test[]) => void;
-  defaultTests: Test[];
+  tests: Test[];
+  setTests: React.Dispatch<React.SetStateAction<Test[]>>;
 }) {
-  const [tests, setTests] = useState<Test[]>(defaultTests);
   const [testName, setTestName] = useState<string>("");
   const { toast } = useToast();
 
@@ -30,7 +29,10 @@ function TestCreator({
     <div className="py-5 overflow-y-scroll">
       <div className="flex flex-col gap-3">
         {tests.map((test, id) => (
-          <div className="rounded-md bg-transparent border-input border-2 border-solid p-3 flex flex-col gap-3">
+          <div
+            key={id}
+            className="rounded-md bg-transparent border-input border-2 border-solid p-3 flex flex-col gap-3"
+          >
             <h1 className="font-bold">{test.name}</h1>
             <StatementCreator
               defaultStatements={test.statements}
@@ -38,7 +40,6 @@ function TestCreator({
                 setTests((prevTests) => {
                   const updatedTests = [...prevTests];
                   updatedTests[id].statements = newStatements;
-                  onChange(updatedTests);
                   return updatedTests;
                 })
               }
@@ -79,7 +80,6 @@ function TestCreator({
                             statements: [],
                           },
                         ];
-                        onChange(updated);
                         return updated;
                       });
                       setTestName("");

--- a/client/src/utils/parseCode.ts
+++ b/client/src/utils/parseCode.ts
@@ -31,7 +31,7 @@ enum Token {
   INVALID = ".",
 }
 
-export function parseCode(code: string): Test[] {
+export function parseCode(code: string): [Test[], boolean] {
   const tests: Test[] = [];
   let token: Token;
   let yytext: string;
@@ -249,6 +249,6 @@ export function parseCode(code: string): Test[] {
   }
 
   token = scanner();
-  program();
-  return tests;
+  const status = program();
+  return [tests, status];
 }


### PR DESCRIPTION
## Description
Added additional checks before switching from code editor to UI editor. Since the user might generate syntax errors which will prevent us to generate the appropriate UI. We don't check the other way around since generating code will be correct.

## Issue
Closes #3.