### PR TITLE
fix: Restore statemend id from parseCode function

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -63,6 +63,7 @@ function Dashboard({ logs, onRerun }: Props) {
     useContext(MainContext);
 
   const [testRuns, setTestRuns] = useState<TestRun[]>([]);
+  const [statementId, setStatementId] = useState<number>(1);
 
   function handleEditorSwitch(checked: boolean) {
     if (checked) {
@@ -87,11 +88,10 @@ function Dashboard({ logs, onRerun }: Props) {
 
   useEffect(() => {
     openDocument(fileName, ({ content }) => {
+      const [parsedTests, _, nextId] = parseCode(content);
       setCode(content);
-      setTests(() => {
-        const [parsedTests] = parseCode(content);
-        return parsedTests;
-      });
+      setTests(parsedTests);
+      setStatementId(nextId);
       toast({
         title: "File opened successfully",
       });
@@ -132,7 +132,7 @@ function Dashboard({ logs, onRerun }: Props) {
             beforeMount={setupEditor}
           />
         ) : (
-          <TestCreator />
+          <TestCreator statementId={statementId} />
         )}
       </ResizablePanel>
       <ResizableHandle withHandle />

--- a/client/src/components/StatementCreator.tsx
+++ b/client/src/components/StatementCreator.tsx
@@ -3,8 +3,6 @@ import ActionInput from "./StatementInput";
 import { useState } from "react";
 import type { Statement } from "@/models/Statement";
 
-let idx = 1; // global idx for statements
-
 function AddActionButton({ onClick }: ButtonProps) {
   return <Button onClick={onClick}>+</Button>;
 }
@@ -12,13 +10,16 @@ function AddActionButton({ onClick }: ButtonProps) {
 type StatementCreatorProps = {
   defaultStatements: Statement[];
   onChange?: (newStatements: Statement[]) => void;
+  statementId: number;
 };
 
 function StatementCreator({
   defaultStatements,
   onChange,
+  statementId,
 }: StatementCreatorProps) {
   const [statements, setStatements] = useState<Statement[]>(defaultStatements);
+  const [id, setId] = useState<number>(statementId);
 
   function onMove(fromId: number, toId: number) {
     setStatements((prevStatements) => {
@@ -59,12 +60,13 @@ function StatementCreator({
               const updated: Statement[] = [
                 ...prevStatements,
                 {
-                  id: idx++,
+                  id,
                   action: "visit",
                   url: "",
                 },
               ];
               if (onChange !== undefined) onChange(updated);
+              setId((prev) => prev + 1);
               return updated;
             })
           }

--- a/client/src/components/TestCreator.tsx
+++ b/client/src/components/TestCreator.tsx
@@ -76,7 +76,7 @@ function AddTestDialog() {
   );
 }
 
-function TestCreator() {
+function TestCreator({ statementId }: { statementId: number }) {
   const { tests, setTests } = useContext(MainContext);
 
   return (
@@ -98,6 +98,7 @@ function TestCreator() {
                     return updatedTests;
                   })
                 }
+                statementId={statementId}
               />
             </div>
           ))}

--- a/client/src/utils/parseCode.ts
+++ b/client/src/utils/parseCode.ts
@@ -31,7 +31,7 @@ enum Token {
   INVALID = ".",
 }
 
-export function parseCode(code: string): [Test[], boolean] {
+export function parseCode(code: string): [Test[], boolean, number] {
   const tests: Test[] = [];
   let token: Token;
   let yytext: string;
@@ -250,5 +250,5 @@ export function parseCode(code: string): [Test[], boolean] {
 
   token = scanner();
   const status = program();
-  return [tests, status];
+  return [tests, status, id];
 }


### PR DESCRIPTION
## Description

When loading the UI editor by default, it is able to correctly parse and loads the statements. However, when the user tries to add new statements, we get a duplicate key error, and drag and drop becomes unstable.

## Solution

To fix this, we make the `parseCode` function return the last id used so it could be then restored by the component and stored in the `statemendId` state.