### PR TITLE
feat: Implemented SSE instead of WebSocket to communicate with client

### DIFF
--- a/api/Compiler/Parser.cs
+++ b/api/Compiler/Parser.cs
@@ -45,7 +45,7 @@ public static class Parser
         return sb.ToString();
     }
 
-    public static string wrapWithSockets(string code, int userId, string fileName)
+    public static string WrapWithSockets(string code, Guid processId)
     {
         StringBuilder sb = new();
 
@@ -67,7 +67,7 @@ public static class Parser
         }}
 
         async function beforeHook() {{
-            socket = new WebSocket('ws://localhost:5064/ws/selenium?fileName={fileName}&userId={userId}');
+            socket = new WebSocket('ws://localhost:5064/ws/selenium?processId={processId}');
             socket.onopen = async function () {{
                 console.log('open');
             }};
@@ -86,30 +86,25 @@ public static class Parser
             socket.close()
         }}
 
-         async function afterEachAssertHook(message, passed, test) {{
+        async function afterEachAssertHook(message, passed, test) {{
             sendAssert(socket, {{
-                test,
+                testName: test,
                 message,
-                passed,
-                type: 1
+                passed
             }});
         }}
 
-         async function beforeEachHook() {{
+        async function beforeEachHook() {{
             sendAssert(socket, {{
-                test: this.currentTest.title,
-                message: null,
-                passed: null,
-                type: 0
+                testName: this.currentTest.title,
+                status: 0
             }});
         }}
         
         async function afterEachHook() {{
             sendAssert(socket, {{
-                test: this.currentTest.title,
-                message: null,
-                passed: this.currentTest.state === 'passed',
-                type: 2
+                testName: this.currentTest.title,
+                status: 1
             }});
 
             await sleep(2000);

--- a/api/Context/TestContext.cs
+++ b/api/Context/TestContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using RestrictedNL.Models;
+using RestrictedNL.Models.Logs;
 using RestrictedNL.Models.User;
 
 namespace RestrictedNL.Context;
@@ -10,4 +11,6 @@ public class TestContext(DbContextOptions options) : DbContext(options)
     public DbSet<TestFile> TestFiles { get; set; }
     public DbSet<TestRun> TestRuns { get; set; }
     public DbSet<User> Users { get; set; }
+    public DbSet<Assertion> Assertions { get; set; }
+    public DbSet<LogGroup> LogGroups { get; set; }
 }

--- a/api/Controllers/TestsController.cs
+++ b/api/Controllers/TestsController.cs
@@ -1,8 +1,10 @@
-using System.Text;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
 using RestrictedNL.Models;
+using RestrictedNL.Models.Redis;
 using RestrictedNL.Models.Token;
+using RestrictedNL.Models.Logs;
 using RestrictedNL.Services;
 
 namespace RestrictedNL.Controllers;
@@ -13,7 +15,9 @@ namespace RestrictedNL.Controllers;
 public class TestsController(
     ITestsRepository testsRepository,
     TestExecutionService testExecutionService,
-    ITokenRepository tokenRepository
+    ITokenRepository tokenRepository,
+    HttpRepository httpRepository,
+    RedisLogsRepository logsRepository
     ) : ControllerBase
 {
     [HttpGet]
@@ -84,54 +88,183 @@ public class TestsController(
     [AllowAnonymous]
     public async Task<IActionResult> Parse(string fileName)
     {
-        if (HttpContext.WebSockets.IsWebSocketRequest)
+        var rawToken = Request.Query["token"].FirstOrDefault()?.Split(" ").Last();
+        if (string.IsNullOrEmpty(rawToken))
         {
-            using var socket = await HttpContext.WebSockets.AcceptWebSocketAsync();
-
-            byte[] buff = new byte[1024 * 4];
-            var result = await socket.ReceiveAsync(new(buff), CancellationToken.None);
-            var rawToken = Encoding.UTF8.GetString(buff, 0, result.Count);
-            var token = tokenRepository.ParseToken(rawToken);
-
-            var id = tokenRepository.GetId(token!);
-            if (id is null) return NotFound("Could not find user with the specified id.");
-
-            await testExecutionService.RunTestAsync(socket, fileName, id.Value, rawToken);
-            return new EmptyResult();
+            return Unauthorized("Token is missing or invalid");
         }
 
-        return BadRequest("This should be a WebSocket connection");
+        var token = tokenRepository.ParseToken(rawToken);
+        if (token is null) return Unauthorized();
+
+        var userId = tokenRepository.GetId(token);
+        if (userId == null)
+        {
+            return Unauthorized("User is not authorized");
+        }
+
+        var testFile = testsRepository.GetTestFile(fileName, (int)userId);
+        if (testFile is null)
+        {
+            Console.WriteLine("Test file not found");
+            return NotFound("Could not find test file");
+        }
+
+        SetSEEHeaders(Response);
+
+        httpRepository.Add((int)userId, testFile.Id.ToString(), Response);
+
+        await testExecutionService.RunTestAsync(testFile, rawToken);
+
+        httpRepository.Remove((int)userId, testFile.Id.ToString());
+
+        return new EmptyResult();
     }
 
     [HttpGet("{fileName}/runs")]
     public ActionResult<List<TestRun>> GetTestsRuns(string fileName)
     {
-        var testRuns = testsRepository.GetTestRuns(fileName);
+        var userId = tokenRepository.GetId(User);
+        if (userId == null)
+        {
+            return Unauthorized("User is not authorized");
+        }
+
+        var testFile = testsRepository.GetTestFile(fileName, (int)userId);
+        if (testFile is null)
+        {
+            Console.WriteLine("Test file not found");
+            return NotFound("Could not find test file");
+        }
+
+        var testRuns = testsRepository.GetTestRuns(testFile.Id);
         if (testRuns is null) return NotFound("Tests runs not found");
 
         return Ok(testRuns);
     }
 
-    [HttpGet("{runId}/compiled/run")]
+    [HttpGet("{fileName}/reconnect")]
     [AllowAnonymous]
-    public async Task<IActionResult> RunCompiled(int runId)
+    public async Task<ActionResult> Reconnect(string fileName)
     {
-        if (HttpContext.WebSockets.IsWebSocketRequest)
+        var rawToken = Request.Query["token"].FirstOrDefault()?.Split(" ").Last();
+        if (string.IsNullOrEmpty(rawToken))
         {
-            using var socket = await HttpContext.WebSockets.AcceptWebSocketAsync();
-
-            byte[] buff = new byte[1024 * 4];
-            var result = await socket.ReceiveAsync(new(buff), CancellationToken.None);
-            var rawToken = Encoding.UTF8.GetString(buff, 0, result.Count);
-            var token = tokenRepository.ParseToken(rawToken);
-
-            var id = tokenRepository.GetId(token!);
-            if (id is null) return NotFound("Could not find user with the specified id.");
-
-            await testExecutionService.RunCompiledTestAsync(socket, id.Value, runId, rawToken);
-            return new EmptyResult();
+            return Unauthorized("Token is missing or invalid");
         }
 
-        return BadRequest("This should be a WebSocket connection");
+        var token = tokenRepository.ParseToken(rawToken);
+        if (token is null) return Unauthorized();
+
+        var userId = tokenRepository.GetId(token);
+        if (userId == null)
+        {
+            return Unauthorized("User is not authorized");
+        }
+
+        var testFile = testsRepository.GetTestFile(fileName, (int)userId);
+        if (testFile is null)
+        {
+            Console.WriteLine("Test file not found");
+            return NotFound("Could not find test file");
+        }
+
+        var testLogKey = new LogKey((int)userId, testFile.Id.ToString());
+        var logs = await logsRepository.Get(testLogKey);
+        if (logs.IsNullOrEmpty())
+        {
+            Console.WriteLine($"No running test to reconnect for test file '{fileName}' and user {userId}");
+            return BadRequest("No running test to reconnect.");
+        }
+        else
+        {
+            SetSEEHeaders(Response);
+            httpRepository.Add((int)userId, testFile.Id.ToString(), Response);
+            await httpRepository.SendSseMessage((int)userId, testFile.Id.ToString(), logs);
+            Console.WriteLine($"Reconnected to test file '{fileName}' for user {userId}");
+
+            try
+            {
+                while (httpRepository.Get((int)userId, testFile.Id.ToString()) is not null)
+                {
+                    await Task.Delay(1000);
+                }
+            }
+            finally
+            {
+                httpRepository.Remove((int)userId, testFile.Id.ToString());
+                Console.WriteLine($"Connection closed for test file '{fileName}' and user {userId}");
+            }
+        }
+
+        return new EmptyResult();
+    }
+
+    [HttpPost("{fileName}/cleanup")]
+    public ActionResult CleanupSSE(string fileName)
+    {
+        var userId = tokenRepository.GetId(User);
+        if (userId == null)
+        {
+            return Unauthorized("User is not authorized");
+        }
+
+        var testFile = testsRepository.GetTestFile(fileName, (int)userId);
+        if (testFile is null)
+        {
+            Console.WriteLine("Test file not found");
+            return NotFound("Could not find test file");
+        }
+
+        httpRepository.Remove((int)userId, testFile.Id.ToString());
+
+        return NoContent();
+    }
+
+    [HttpGet("{runId}/compiled/run")]
+    [AllowAnonymous]
+    public async Task<IActionResult> RunCompiled(Guid runId)
+    {
+        var rawToken = Request.Query["token"].FirstOrDefault()?.Split(" ").Last();
+        if (string.IsNullOrEmpty(rawToken))
+        {
+            return Unauthorized("Token is missing or invalid");
+        }
+
+        var token = tokenRepository.ParseToken(rawToken);
+        if (token is null)
+        {
+            return Unauthorized();
+        }
+
+        var userId = tokenRepository.GetId(token);
+        if (userId == null)
+        {
+            return Unauthorized("User is not authorized");
+        }
+
+        var testRun = testsRepository.GetTestRun(runId);
+
+        if (testRun is null)
+        {
+            return NotFound("Run not found");
+        }
+
+        SetSEEHeaders(Response);
+
+        httpRepository.Add((int)userId, testRun.FileId.ToString(), Response);
+
+        await testExecutionService.RunCompiledTestAsync((int)userId, testRun, rawToken);
+
+        httpRepository.Remove((int)userId, testRun.FileId.ToString());
+
+        return new EmptyResult();
+    }
+
+    private static void SetSEEHeaders(HttpResponse response)
+    {
+        response.ContentType = "text/event-stream";
+        response.Headers.CacheControl = "no-cache";
+        response.Headers.Connection = "keep-alive";
     }
 }

--- a/api/Middlewares/WebSocketMiddleware.cs
+++ b/api/Middlewares/WebSocketMiddleware.cs
@@ -1,42 +1,33 @@
 using RestrictedNL.Models;
+using RestrictedNL.Models.Logs;
 using System.Net.WebSockets;
 using System.Text;
 using Newtonsoft.Json;
-using System.Collections.Concurrent;
+using RestrictedNL.Models.Redis;
+using Newtonsoft.Json.Linq;
 
 namespace RestrictedNL.Middlewares;
 
-public record TestLogKey(int UserId, string FileName);
-
-public record LogMessage(string Test, LogType Type, string? Message, bool? Passed);
-
-public enum LogType
-{
-    BEFORE_EACH_MESSAGE = 0,
-    AFTER_EACH_ASSERT_MESSAGE = 1,
-    AFTER_EACH_MESSAGE = 2
-}
-public class TestLogGroupItem
-{
-    public required LogMessage Test;
-    public required List<LogMessage> Assertions;
-};
-
 public class WebSocketMiddleware(RequestDelegate next)
 {
-    // this should be moved to a db like redis>>>>>>><<<<<<<<please. after tuesday
-    private static readonly ConcurrentDictionary<TestLogKey, List<TestLogGroupItem>> TestLogGroup = new();
-
     private static async Task HandleSelenium(HttpContext context)
     {
         var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
-        var _socketsRepo = context.RequestServices.GetRequiredService<SocketsRepository>();
+        var _httpRepo = context.RequestServices.GetRequiredService<HttpRepository>();
+        var _logsRepo = context.RequestServices.GetRequiredService<RedisLogsRepository>();
+        var _processRepo = context.RequestServices.GetRequiredService<RedisProcessRepository>();
 
         if (context.WebSockets.IsWebSocketRequest)
         {
-            var fileName = context.Request.Query["fileName"].ToString();
-            var userId = int.Parse(context.Request.Query["userId"].ToString());
+            var processId = Guid.Parse(context.Request.Query["processId"].ToString());
+            var key = await _processRepo.Get(processId);
+            if (key is null)
+            {
+                logger.LogInformation("Process missing from repo");
+                return;
+            }
 
+            // Accept WebSocket connection from selenium
             using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
             while (webSocket.State == WebSocketState.Open)
             {
@@ -44,51 +35,37 @@ public class WebSocketMiddleware(RequestDelegate next)
                 var result = await webSocket.ReceiveAsync(new(buff), CancellationToken.None);
                 if (result.MessageType == WebSocketMessageType.Close)
                 {
+                    logger.LogInformation("WebSocket connection closing...");
+                    await _processRepo.Remove(processId);
+
                     await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
                     logger.LogInformation("WebSocket connection closed.");
-                    var key = new TestLogKey(userId, fileName);
-                    //Save in database before removing ?? But don't we need to save it under a run id?????????? how do we fetch the run id of this one????
-                    TestLogGroup.TryRemove(key, out _);
                     break;
                 }
 
+                // Process the message from selenium
                 var message = Encoding.UTF8.GetString(buff, 0, result.Count);
-                var log = JsonConvert.DeserializeObject<LogMessage>(message);
+                Console.WriteLine($"Received message = {message}");
+                var obj = JsonConvert.DeserializeObject<JObject>(message);
 
-                if (log is not null)
+                if (obj is not null)
                 {
-                    var logKey = new TestLogKey(userId, fileName);
-
-                    if (log.Type != LogType.AFTER_EACH_ASSERT_MESSAGE)
+                    if (obj["message"] is null)
                     {
-                        var testBlocks = TestLogGroup.GetValueOrDefault(logKey, []);
-                        var testBlock = testBlocks.FirstOrDefault(group => group.Test.Test == log.Test);
-                        if (testBlock is not null)
-                        {
-                            testBlock.Test = log;
-                        }
-                        else
-                        {
-                            testBlocks.Add(new TestLogGroupItem
-                            {
-                                Test = log,
-                                Assertions = []
-                            });
-                        }
-
-                        TestLogGroup.AddOrUpdate(logKey, [new TestLogGroupItem
-                        {
-                            Test = log,
-                            Assertions = []
-                        }], (key, val) => testBlocks);
+                        logger.LogInformation("Is LogGroup");
+                        await _logsRepo.AddLogGroup(key, obj.ToObject<LogGroup>()!);
+                    }
+                    else if (obj["message"] is not null)
+                    {
+                        logger.LogInformation("Is Assertion");
+                        await _logsRepo.AddAssertion(key, obj.ToObject<Assertion>()!);
                     }
                     else
                     {
-                        TestLogGroup[logKey].Find(group => group.Test.Test == log.Test)?.Assertions.Add(log);
+                        logger.LogInformation("Message did not match any expected types");
                     }
 
-                    var testGroups = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(TestLogGroup[logKey]));
-                    await _socketsRepo.GetSocket(logKey.UserId).SendAsync(new(testGroups, 0, testGroups.Length), WebSocketMessageType.Text, true, CancellationToken.None);
+                    await _httpRepo.SendSseMessage(key.UserId, key.FileId, await _logsRepo.Get(key));
                 }
             }
         }

--- a/api/Models/HttpRepository.cs
+++ b/api/Models/HttpRepository.cs
@@ -1,0 +1,61 @@
+using System.Collections.Concurrent;
+using Newtonsoft.Json;
+using RestrictedNL.Models.Redis;
+using RestrictedNL.Models.Logs;
+
+namespace RestrictedNL.Models;
+
+public class HttpRepository
+{
+    private readonly ConcurrentDictionary<LogKey, HttpResponse> ActiveConnections = new();
+
+    public void Add(int userId, string fileName, HttpResponse response)
+    {
+        LogKey key = new(userId, fileName);
+        ActiveConnections[key] = response;
+    }
+
+    public HttpResponse? Get(int userId, string fileName)
+    {
+        LogKey key = new(userId, fileName);
+
+        if (ActiveConnections.TryGetValue(key, out var response))
+        {
+            return response;
+        }
+
+        return null;
+    }
+
+    public void Remove(int userId, string fileName)
+    {
+        LogKey key = new(userId, fileName);
+        ActiveConnections.TryRemove(key, out _);
+    }
+
+    public async Task SendSseMessage(int userId, string fileId, List<LogGroup> message, string status = "healthy")
+    {
+        var response = Get(userId, fileId);
+
+        if (response != null)
+        {
+            var sseObject = JsonConvert.SerializeObject(new
+            {
+                message,
+                status
+            });
+
+            var data = $"data: {sseObject}\n\n";
+
+            await response.WriteAsync(data);
+
+            Console.WriteLine(data);
+
+            await response.Body.FlushAsync();
+        }
+        else
+        {
+            Console.WriteLine("Response is null");
+        }
+    }
+}

--- a/api/Models/ITestsRepository.cs
+++ b/api/Models/ITestsRepository.cs
@@ -7,7 +7,7 @@ public interface ITestsRepository
     Task DeleteTestFile(TestFile file);
     Task UploadTestFile(int userId, string fileName, string content);
     Task UpdateTestFile(TestFile file, string content);
-    TestRun? GetTestRun(int runId);
-    List<TestRun> GetTestRuns(string fileName);
+    TestRun? GetTestRun(Guid runId);
+    List<TestRun> GetTestRuns(int fileId);
     Task UploadTestRun(TestRun testRun);
 }

--- a/api/Models/Logs/Assertion.cs
+++ b/api/Models/Logs/Assertion.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RestrictedNL.Models.Logs;
+
+[Table("assertions")]
+public record Assertion
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Column("run_id")]
+    public Guid RunId { get; set; }
+
+    [Column("test_name")]
+    public required string TestName { get; set; }
+
+    [Column("message")]
+    public required string Message { get; set; }
+
+    [Column("passed")]
+    public required bool Passed { get; set; }
+}

--- a/api/Models/Logs/Logs.cs
+++ b/api/Models/Logs/Logs.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RestrictedNL.Models.Logs;
+
+public record LogKey(int UserId, string FileId)
+{
+    public override string ToString() => $"Logs_{UserId}:{FileId}";
+};
+
+[Table("log_groups")]
+public record LogGroup
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Column("test_name")]
+    public required string TestName { get; set; }
+
+    [Column("status")]
+    public required LogStatus Status { get; set; }
+
+    [Column("run_id")]
+    public Guid RunId { get; set; }
+
+    [NotMapped]
+    public List<Assertion> Assertions = [];
+};
+
+public enum LogStatus
+{
+    LOADING = 0,
+    FINISHED = 1
+}

--- a/api/Models/Redis/RedisLogsRepository.cs
+++ b/api/Models/Redis/RedisLogsRepository.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Newtonsoft.Json;
+using RestrictedNL.Context;
+using RestrictedNL.Models.Logs;
+
+namespace RestrictedNL.Models.Redis;
+
+// The Redis cache contains data in the following format
+// LogKey => List<LogGroup>
+public class RedisLogsRepository(IDistributedCache cache, TestContext context)
+{
+    private readonly IDistributedCache _cache = cache;
+
+    public async Task AddLogGroup(LogKey key, LogGroup group)
+    {
+        var groups = await Get(key);
+        var g = groups.FirstOrDefault(g => g.TestName == group.TestName);
+
+        if (g is null) groups.Add(group);
+        else g.Status = group.Status;
+
+        var serializedGroups = JsonConvert.SerializeObject(groups);
+        await _cache.SetStringAsync(key.ToString(), serializedGroups);
+    }
+
+    public async Task AddAssertion(LogKey key, Assertion assertion)
+    {
+        var groups = await Get(key);
+        var group = groups.FirstOrDefault(g => g.TestName == assertion.TestName);
+        if (group is null) return;
+
+        group.Assertions.Add(assertion);
+        await _cache.SetStringAsync(key.ToString(), JsonConvert.SerializeObject(groups));
+    }
+
+    public async Task<List<LogGroup>> Get(LogKey key)
+    {
+        var cachedItem = await _cache.GetStringAsync(key?.ToString() ?? "");
+        if (string.IsNullOrEmpty(cachedItem)) return [];
+        var deseralizedLogs = JsonConvert.DeserializeObject<List<LogGroup>>(cachedItem);
+        return deseralizedLogs ?? [];
+    }
+
+    public async Task Save(LogKey key, Guid runId)
+    {
+        var groups = (await Get(key)).Select(group =>
+        {
+            group.RunId = runId;
+            return group;
+        });
+
+        var assertions = groups.Select(g => g.Assertions.Select(a =>
+        {
+            a.RunId = runId;
+            return a;
+        }));
+
+        await context.LogGroups.AddRangeAsync(groups);
+        foreach (var asserts in assertions)
+            await context.Assertions.AddRangeAsync(asserts);
+
+        await context.SaveChangesAsync();
+    }
+
+    public async Task Remove(LogKey key) => await _cache.RemoveAsync(key?.ToString() ?? "");
+}

--- a/api/Models/Redis/RedisProcessRepository.cs
+++ b/api/Models/Redis/RedisProcessRepository.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Newtonsoft.Json;
+using RestrictedNL.Models.Logs;
+
+namespace RestrictedNL.Models.Redis;
+
+public class RedisProcessRepository(IDistributedCache cache)
+{
+    private readonly IDistributedCache _cache = cache;
+    private static string GetKey(Guid processId) => $"Process_{processId}";
+
+    public async Task Add(Guid processId, int userId, string fileName)
+    {
+        string cacheKey = GetKey(processId);
+
+        var seralizedLogKey = JsonConvert.SerializeObject(new LogKey(userId, fileName));
+
+        await _cache.SetStringAsync(cacheKey, seralizedLogKey);
+    }
+
+    public async Task<LogKey?> Get(Guid processId)
+    {
+        string cacheKey = GetKey(processId);
+
+        var cachedItem = await _cache.GetStringAsync(cacheKey);
+
+        if (string.IsNullOrEmpty(cachedItem)) return null;
+
+        return JsonConvert.DeserializeObject<LogKey>(cachedItem);
+    }
+
+    public async Task Remove(Guid processId)
+    {
+        string cacheKey = GetKey(processId);
+        await _cache.RemoveAsync(cacheKey);
+    }
+}

--- a/api/Models/TestRun.cs
+++ b/api/Models/TestRun.cs
@@ -7,12 +7,12 @@ namespace RestrictedNL.Models;
 public record TestRun
 {
     [Key]
-    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     [Column("id")]
-    public int Id { get; set; }
+    public required Guid Id { get; set; }
 
-    [Column("name")]
-    public required string Name { get; set; }
+    [ForeignKey("fileId")]
+    [Column("file_id")]
+    public required int FileId { get; set; }
 
     [Column("ran_at")]
     public required DateTime RanAt { get; set; }

--- a/api/Models/TestsRepository.cs
+++ b/api/Models/TestsRepository.cs
@@ -17,11 +17,11 @@ public class TestsRepository(TestContext context) : ITestsRepository
         await context.SaveChangesAsync();
     }
 
-    public TestRun? GetTestRun(int runId)
+    public TestRun? GetTestRun(Guid runId)
         => context.TestRuns.Where(test => test.Id == runId).FirstOrDefault();
 
-    public List<TestRun> GetTestRuns(string fileName)
-        => context.TestRuns.Where(test => test.Name == fileName).ToList();
+    public List<TestRun> GetTestRuns(int fileId)
+        => context.TestRuns.Where(test => test.FileId == fileId).ToList();
 
     public async Task UpdateTestFile(TestFile file, string content)
     {

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -6,6 +6,7 @@ using RestrictedNL.Context;
 using RestrictedNL.Middlewares;
 using RestrictedNL.Models;
 using RestrictedNL.Models.Token;
+using RestrictedNL.Models.Redis;
 using RestrictedNL.Models.User;
 using RestrictedNL.Services;
 
@@ -22,6 +23,9 @@ builder.Services.AddControllers().AddNewtonsoftJson();
 builder.Services.AddScoped<ITestsRepository, TestsRepository>();
 builder.Services.AddSingleton<SocketsRepository>();
 builder.Services.AddScoped<TestExecutionService>();
+builder.Services.AddScoped<RedisLogsRepository>();
+builder.Services.AddScoped<RedisProcessRepository>();
+builder.Services.AddSingleton<HttpRepository>();
 
 builder.Services.AddScoped<ITokenRepository, TokenRepository>();
 builder.Services.AddScoped<TokenGenerator>();
@@ -31,6 +35,12 @@ builder.Services.AddDbContext<TestContext>(options =>
 {
     options.UseNpgsql(builder.Configuration["ConnectionStrings:DB"]);
 });
+
+builder.Services.AddStackExchangeRedisCache(options =>
+ {
+     options.Configuration = builder.Configuration["ConnectionStrings:Redis"];
+     options.InstanceName = "SampleInstance";
+ });
 
 // Configure authentication & JWT
 builder.Services

--- a/api/appsettings.Development.json
+++ b/api/appsettings.Development.json
@@ -11,6 +11,7 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DB": "Username=postgres; Password=postgres; Host=localhost; Database = restrictednl-db;",
+    "Redis": "127.0.0.1:6379",
     "SeeClick": "http://localhost:5000/coordinates"
   }
 }

--- a/api/fyp-backend.csproj
+++ b/api/fyp-backend.csproj
@@ -15,15 +15,22 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 
 	<ItemGroup>
-		<Folder Include="Controllers\" />
-		<Folder Include="Models\" />
-		<Folder Include="Models\User" />
-		<Folder Include="Models\Token" />
+    <Folder Include="Controllers\" />
+    <Folder Include="Models\" />
+    <Folder Include="Models\User" />
+    <Folder Include="Models\Token" />
+    <Folder Include="Models\Logs" />
+    <Folder Include="Models\Redis" />
     <Folder Include="Compiler\" />
 	</ItemGroup>
 </Project>

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -10,7 +10,7 @@ import { useContext, useEffect, useState } from "react";
 import { MainContext } from "@/context/MainContext";
 import { TestRun } from "@/models/TestRun";
 import TestRunTable from "./TestRunTable";
-import TestLogs, { TestLogGroup } from "./TestLogs";
+import TestLogs from "./TestLogs";
 import TestCreator from "./TestCreator";
 import { Switch } from "@/shadcn/components/ui/switch";
 import { Label } from "@/shadcn/components/ui/label";
@@ -21,9 +21,10 @@ import { toast } from "@/shadcn/hooks/use-toast";
 import { TestFile } from "@/models/TestFile";
 import { UserContext } from "@/context/UserContext";
 import { API_URL } from "@/main";
+import { LogGroup } from "@/models/Log";
 
 type Props = {
-  logs: TestLogGroup[];
+  logs: LogGroup[];
   onRerun: (id: number) => void;
   testRuns: TestRun[];
 };

--- a/client/src/components/DataTable.tsx
+++ b/client/src/components/DataTable.tsx
@@ -78,14 +78,14 @@ export function DataTable<TData, TValue>({
   return (
     <div className="flex flex-col gap-4 py-4">
       <div className="flex items-center">
-        <Input
+        {/* <Input
           placeholder="Filter..."
           value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
             table.getColumn("name")?.setFilterValue(event.target.value)
           }
           className="max-w-sm"
-        />
+        /> */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" className="ml-auto">

--- a/client/src/components/TestLogs.tsx
+++ b/client/src/components/TestLogs.tsx
@@ -1,29 +1,26 @@
 import { ChevronRight, CircleCheck, CircleX, LoaderCircle } from "lucide-react";
-import { Log, LogType } from "@/models/Log";
+import { LogGroup, LogStatus } from "@/models/Log";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/shadcn/components/ui/collapsible";
 
-type Props = { logs: TestLogGroup[] };
-
-export type TestLogGroup = {
-  Assertions: Log[];
-  Test: Log;
-};
+type Props = { logs: LogGroup[] };
 
 function TestLogs({ logs }: Props) {
   return (
     <div className="flex flex-col gap-3">
-      {logs.map(({ Test, Assertions }) => (
-        <TestDropdown key={Test.Test} test={Test} asserts={Assertions} />
+      {logs.map((group) => (
+        <TestDropdown key={group.TestName} logGroup={group} />
       ))}
     </div>
   );
 }
 
-function TestDropdown({ test, asserts }: { test: Log; asserts: Log[] }) {
+function TestDropdown({ logGroup }: { logGroup: LogGroup }) {
+  const { TestName, Assertions, Status } = logGroup;
+
   return (
     <Collapsible defaultOpen className="group/collapsible">
       <CollapsibleTrigger
@@ -35,18 +32,18 @@ function TestDropdown({ test, asserts }: { test: Log; asserts: Log[] }) {
             size={20}
             className="transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
           />
-          {test.Type !== LogType.AFTER_EACH_MESSAGE ? (
+          {Status === LogStatus.LOADING ? (
             <LoaderCircle className="animate-spin" />
-          ) : test.Passed ? (
+          ) : Assertions.every((a) => a.Passed) ? (
             <CircleCheck color="green" />
           ) : (
             <CircleX color="red" />
           )}
-          <p>{test.Test}</p>
+          <p>{TestName}</p>
         </div>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        {asserts.map((log, index) => {
+        {Assertions.map((log, index) => {
           return (
             <div key={index} className="flex items-center gap-2 py-3">
               {log.Passed ? (

--- a/client/src/models/Log.ts
+++ b/client/src/models/Log.ts
@@ -1,12 +1,16 @@
-export type Log = {
-  Test: string;
-  Message: string | null;
-  Passed: boolean | null;
-  Type: LogType;
+export type Assertion = {
+  TestName: string;
+  Message: string;
+  Passed: boolean;
 };
 
-export enum LogType {
-  BEFORE_EACH_MESSAGE = 0,
-  AFTER_EACH_ASSERT_MESSAGE = 1,
-  AFTER_EACH_MESSAGE = 2,
+export enum LogStatus {
+  LOADING = 0,
+  FINISHED = 1,
 }
+
+export type LogGroup = {
+  TestName: string;
+  Status: LogStatus;
+  Assertions: Assertion[];
+};


### PR DESCRIPTION
## Description

- Implemented Server-Side Events instead of WebSockets for sending updates to the client. Selenium still communicates with the API using WebSockets for now.
- Save logs to DB for future reference.
- Handle running multiple files simultaneously and session persistence, i.e. the user can exit and come back to the test while still receiving updates.

## Related issues

Closes #26.
Closes #20.
Partially fixes #19.