### PR TITLE
refactor: Implement hooks to simplify network requests + SSE

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-switch": "^1.1.1",
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.6",
+        "@tanstack/react-query": "^5.64.2",
         "@tanstack/react-table": "^8.20.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3397,6 +3398,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.64.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.64.2.tgz",
+      "integrity": "sha512-hdO8SZpWXoADNTWXV9We8CwTkXU88OVWRBcsiFrk7xJQnhm6WRlweDzMD+uH+GnuieTBVSML6xFa17C2cNV8+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.64.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.64.2.tgz",
+      "integrity": "sha512-3pakNscZNm8KJkxmovvtZ4RaXLyiYYobwleTMvpIGUoKRa8j8VlrQKNl5W8VUEfVfZKkikvXVddLuWMbcSCA1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.64.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@tanstack/react-table": {
       "version": "8.20.6",

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-switch": "^1.1.1",
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.6",
+    "@tanstack/react-query": "^5.64.2",
     "@tanstack/react-table": "^8.20.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import { jwtDecode } from "jwt-decode";
 import RootLayout from "./layouts/RootLayout";
 import RunsScreen from "./screens/RunsScreen";
 import ViewRunScreen from "./screens/ViewRunScreen";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 function App() {
   const [user, setUser] = useState<User | null>(null);
@@ -60,27 +61,34 @@ function App() {
         { path: "tests/:testId/runs", element: authorize(<RunsScreen />) },
       ],
     },
-    { path: "/runs/:runId", element: authorize(<ViewRunScreen />) },
+    {
+      path: "/tests/:testId/runs/:runId",
+      element: authorize(<ViewRunScreen />),
+    },
     { path: "/auth/login", element: anonymous(<LoginScreen />) },
     { path: "/auth/signup", element: anonymous(<SignUpScreen />) },
     { path: "/editor/:testId", element: authorize(<EditorScreen />) },
   ]);
 
+  const queryClient = new QueryClient();
+
   return (
     <DndProvider backend={HTML5Backend}>
       <ThemeProvider defaultTheme="dark">
-        <UserContext.Provider
-          value={{
-            user,
-            setUser,
-            token,
-            setToken,
-            isAuthenticated,
-            setIsAuthenticated,
-          }}
-        >
-          {authInitialized && <RouterProvider router={router} />}
-        </UserContext.Provider>
+        <QueryClientProvider client={queryClient}>
+          <UserContext.Provider
+            value={{
+              user,
+              setUser,
+              token,
+              setToken,
+              isAuthenticated,
+              setIsAuthenticated,
+            }}
+          >
+            {authInitialized && <RouterProvider router={router} />}
+          </UserContext.Provider>
+        </QueryClientProvider>
       </ThemeProvider>
     </DndProvider>
   );

--- a/client/src/components/Editor.tsx
+++ b/client/src/components/Editor.tsx
@@ -3,8 +3,6 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/shadcn/components/ui/resizable";
-import { ScrollArea } from "@/shadcn/components/ui/scroll-area";
-
 import { Editor as MonacoEditor } from "@monaco-editor/react";
 import { useContext, useEffect, useState } from "react";
 import { MainContext } from "@/context/MainContext";
@@ -22,9 +20,7 @@ import { API_URL } from "@/main";
 import { LogGroup } from "@/models/Log";
 import { Card } from "@/shadcn/components/ui/card";
 
-type Props = {
-  logs: LogGroup[];
-};
+type Props = { logs: LogGroup[] };
 
 async function openDocument(
   fileId: string,
@@ -125,17 +121,9 @@ function Editor({ logs }: Props) {
       </ResizablePanel>
       <ResizableHandle withHandle />
       <ResizablePanel defaultSize={20} className="py-3">
-        <Card className="p-4 flex flex-col gap-3">
+        <Card className="p-4 flex flex-col gap-3 h-full w-full">
           <h1 className="font-bold text-2xl">Logs</h1>
-          <ScrollArea>
-            {Object.keys(logs).length === 0 ? (
-              <p>There are no tests running yet. Try running a test first!</p>
-            ) : (
-              <div className="flex flex-col gap-3">
-                <TestLogs logs={logs} />
-              </div>
-            )}
-          </ScrollArea>
+          <TestLogs logs={logs} />
         </Card>
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/client/src/components/HomeSideBar.tsx
+++ b/client/src/components/HomeSideBar.tsx
@@ -32,6 +32,8 @@ import { useTheme } from "@/shadcn/components/theme-provider";
 import { NavUser } from "./NavUser";
 import { UserContext } from "@/context/UserContext";
 import { API_URL } from "@/main";
+import { MainContext } from "@/context/MainContext";
+import { TestFile } from "@/models/TestFile";
 
 type HomeSideBarProps = {
   children: React.ReactNode;
@@ -39,6 +41,7 @@ type HomeSideBarProps = {
 
 function HomeSideBar({ children }: HomeSideBarProps) {
   const { user, token } = useContext(UserContext);
+  const { setFileId } = useContext(MainContext);
   const [fileName, setFileName] = useState<string>("");
   const { theme, setTheme } = useTheme();
   const navigate = useNavigate();
@@ -62,6 +65,10 @@ function HomeSideBar({ children }: HomeSideBarProps) {
       });
       return;
     }
+
+    const file: TestFile = await res.json();
+    setFileId(file.id);
+    return file.id;
   }
 
   return (
@@ -102,9 +109,9 @@ function HomeSideBar({ children }: HomeSideBarProps) {
                             <Button
                               type="button"
                               variant="default"
-                              onClick={() => {
-                                createFile(fileName);
-                                navigate(`/editor/${fileName}`);
+                              onClick={async () => {
+                                const id = await createFile(fileName);
+                                navigate(`/editor/${id}`);
                               }}
                             >
                               Create

--- a/client/src/components/Menu.tsx
+++ b/client/src/components/Menu.tsx
@@ -9,14 +9,15 @@ import { MainContext } from "@/context/MainContext";
 import { useTheme } from "@/shadcn/components/theme-provider";
 import { Moon, Sun } from "lucide-react";
 import { Link } from "react-router";
+import { useSave } from "@/hooks/useSave";
+import { useShortcut } from "@/hooks/useShortcut";
 
-type Props = {
-  onRun: () => void;
-  onSave: (fileId: string) => void;
-};
+type Props = { onRun: () => void };
 
-function Menu({ onRun, onSave }: Props) {
-  const { fileId } = useContext(MainContext);
+function Menu({ onRun }: Props) {
+  const { fileId, code } = useContext(MainContext);
+  const { saveDocument } = useSave();
+  useShortcut(() => saveDocument(fileId, code), onRun);
 
   const { theme, setTheme } = useTheme();
 
@@ -30,7 +31,9 @@ function Menu({ onRun, onSave }: Props) {
         </MenubarMenu>
         <MenubarMenu>
           <MenubarMenu>
-            <MenubarTrigger onClick={() => onSave(fileId)}>Save</MenubarTrigger>
+            <MenubarTrigger onClick={() => saveDocument(fileId, code)}>
+              Save
+            </MenubarTrigger>
           </MenubarMenu>
           <MenubarMenu>
             <MenubarTrigger onClick={onRun} disabled={!fileId}>

--- a/client/src/components/TestLogDropdown.tsx
+++ b/client/src/components/TestLogDropdown.tsx
@@ -1,0 +1,55 @@
+import { LogGroup, LogStatus } from "@/models/Log";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/shadcn/components/ui/collapsible";
+import { ChevronRight, CircleCheck, CircleX, LoaderCircle } from "lucide-react";
+
+type Props = { logGroup: LogGroup };
+
+function TestLogDropdown({ logGroup }: Props) {
+  const { testName, assertions, status } = logGroup;
+
+  return (
+    <Collapsible defaultOpen className="group/collapsible">
+      <CollapsibleTrigger
+        asChild
+        className="cursor-pointer font-bold text-lg border-input border-2 rounded-lg p-2 w-full"
+      >
+        <div className="flex flex-row gap-3 items-center">
+          {status !== LogStatus.LOADING && assertions.length > 0 && (
+            <ChevronRight
+              size={20}
+              className={`transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90`}
+            />
+          )}
+          {status === LogStatus.LOADING ? (
+            <LoaderCircle className="animate-spin" />
+          ) : assertions.every((a) => a.passed) ? (
+            <CircleCheck color="green" />
+          ) : (
+            <CircleX color="red" />
+          )}
+          <p>{testName}</p>
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        {assertions.map((log, index) => {
+          return (
+            <div key={index} className="flex items-center gap-2 py-3">
+              {log.passed ? (
+                <CircleCheck color="green" />
+              ) : (
+                <CircleX color="red" />
+              )}
+              <p>{log.message}</p>
+            </div>
+          );
+        })}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export default TestLogDropdown;

--- a/client/src/components/TestLogs.tsx
+++ b/client/src/components/TestLogs.tsx
@@ -1,64 +1,19 @@
-import { ChevronRight, CircleCheck, CircleX, LoaderCircle } from "lucide-react";
-import { LogGroup, LogStatus } from "@/models/Log";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/shadcn/components/ui/collapsible";
+import { LogGroup } from "@/models/Log";
+import TestLogDropdown from "./TestLogDropdown";
 
 type Props = { logs: LogGroup[] };
 
 function TestLogs({ logs }: Props) {
   return (
-    <div className="flex flex-col gap-3">
-      {logs.map((group) => (
-        <TestDropdown key={group.testName} logGroup={group} />
-      ))}
+    <div className="flex flex-col gap-3 h-full w-full">
+      {Object.keys(logs).length === 0 ? (
+        <p>There are no tests running yet. Try running a test first!</p>
+      ) : (
+        logs.map((group) => (
+          <TestLogDropdown key={group.testName} logGroup={group} />
+        ))
+      )}
     </div>
-  );
-}
-
-function TestDropdown({ logGroup }: { logGroup: LogGroup }) {
-  const { testName, assertions, status } = logGroup;
-
-  return (
-    <Collapsible defaultOpen className="group/collapsible">
-      <CollapsibleTrigger
-        asChild
-        className="cursor-pointer font-bold text-lg border-input border-2 rounded-lg p-2 w-full"
-      >
-        <div className="flex flex-row gap-3 items-center">
-          {status !== LogStatus.LOADING && assertions.length > 0 && (
-            <ChevronRight
-              size={20}
-              className={`transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90`}
-            />
-          )}
-          {status === LogStatus.LOADING ? (
-            <LoaderCircle className="animate-spin" />
-          ) : assertions.every((a) => a.passed) ? (
-            <CircleCheck color="green" />
-          ) : (
-            <CircleX color="red" />
-          )}
-          <p>{testName}</p>
-        </div>
-      </CollapsibleTrigger>
-      <CollapsibleContent>
-        {assertions.map((log, index) => {
-          return (
-            <div key={index} className="flex items-center gap-2 py-3">
-              {log.passed ? (
-                <CircleCheck color="green" />
-              ) : (
-                <CircleX color="red" />
-              )}
-              <p>{log.message}</p>
-            </div>
-          );
-        })}
-      </CollapsibleContent>
-    </Collapsible>
   );
 }
 

--- a/client/src/components/TestRunTable.tsx
+++ b/client/src/components/TestRunTable.tsx
@@ -2,9 +2,8 @@ import { TestRun } from "@/models/TestRun";
 import { Button } from "@/shadcn/components/ui/button";
 import { ScrollArea } from "@/shadcn/components/ui/scroll-area";
 import { DataTable } from "./DataTable";
-import { Column, ColumnDef } from "@tanstack/react-table";
+import { ColumnDef } from "@tanstack/react-table";
 import {
-  ArrowUpDown,
   Binoculars,
   CircleCheck,
   CircleX,
@@ -20,21 +19,9 @@ import {
   DropdownMenuTrigger,
 } from "@/shadcn/components/ui/dropdown-menu";
 import { useNavigate } from "react-router";
+import { sortHeader } from "@/utils/sortHeader";
 
 type Props = { testRuns: TestRun[]; onRerun: (run: TestRun) => void };
-
-const sortHeader = (name: string) => {
-  return ({ column }: { column: Column<TestRun, unknown> }) => (
-    <Button
-      variant="ghost"
-      className="p-0 hover:bg-transparent"
-      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-    >
-      {name}
-      <ArrowUpDown className="ml-2 h-4 w-4" />
-    </Button>
-  );
-};
 
 function TestRunTable({ testRuns, onRerun }: Props) {
   const navigate = useNavigate();

--- a/client/src/components/TestRunTable.tsx
+++ b/client/src/components/TestRunTable.tsx
@@ -3,13 +3,7 @@ import { Button } from "@/shadcn/components/ui/button";
 import { ScrollArea } from "@/shadcn/components/ui/scroll-area";
 import { DataTable } from "./DataTable";
 import { ColumnDef } from "@tanstack/react-table";
-import {
-  Binoculars,
-  CircleCheck,
-  CircleX,
-  MoreHorizontal,
-  RefreshCcw,
-} from "lucide-react";
+import { Binoculars, CircleCheck, CircleX, MoreHorizontal } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -21,9 +15,12 @@ import {
 import { useNavigate } from "react-router";
 import { sortHeader } from "@/utils/sortHeader";
 
-type Props = { testRuns: TestRun[]; onRerun: (run: TestRun) => void };
+type Props = {
+  testId: string;
+  testRuns: TestRun[];
+};
 
-function TestRunTable({ testRuns, onRerun }: Props) {
+function TestRunTable({ testId, testRuns }: Props) {
   const navigate = useNavigate();
 
   function Actions({ run }: { run: TestRun }) {
@@ -40,15 +37,12 @@ function TestRunTable({ testRuns, onRerun }: Props) {
           <DropdownMenuSeparator />
           <DropdownMenuItem
             onClick={() =>
-              navigate(`/runs/${run.id}`, {
+              navigate(`/tests/${testId}/runs/${run.id}`, {
                 state: run,
               })
             }
           >
             <Binoculars /> View test
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => onRerun(run)}>
-            <RefreshCcw /> Replay test
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/client/src/hooks/useSave.ts
+++ b/client/src/hooks/useSave.ts
@@ -1,0 +1,58 @@
+import { MainContext } from "@/context/MainContext";
+import { UserContext } from "@/context/UserContext";
+import { API_URL } from "@/main";
+import { useToast } from "@/shadcn/hooks/use-toast";
+import { generateCode } from "@/utils/generateCode";
+import { parseCode } from "@/utils/parseCode";
+import { useContext } from "react";
+
+export function useSave() {
+  const { toast } = useToast();
+  const { token } = useContext(UserContext);
+  const { setCode, isCode, tests } = useContext(MainContext);
+
+  async function saveDocument(fileId: string, code: string) {
+    if (!isCode) {
+      const generatedCode = generateCode(tests);
+      const [, status] = parseCode(generatedCode);
+
+      if (status) {
+        setCode(generatedCode);
+        code = generatedCode;
+      } else {
+        toast({
+          title: "Test syntax error!",
+          description:
+            "Please make sure you have filled out all the fields correctly then try again. Your progress is unsaved.",
+          variant: "destructive",
+        });
+      }
+    }
+
+    const res = await fetch(`${API_URL}/api/tests/${fileId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        fileName: fileId, // TODO: FIX
+        content: code,
+      }),
+    });
+
+    if (!res.ok) {
+      toast({
+        title: await res.text(),
+        variant: "destructive",
+      });
+      return;
+    }
+
+    toast({
+      title: "Saved successfully!",
+    });
+  }
+
+  return { saveDocument };
+}

--- a/client/src/hooks/useShortcut.ts
+++ b/client/src/hooks/useShortcut.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+export function useShortcut(onSave: () => void, onRun: () => void) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+        event.preventDefault();
+        onSave();
+      } else if ((event.ctrlKey || event.metaKey) && event.key === "e") {
+        event.preventDefault();
+        onRun();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onSave, onRun]);
+}

--- a/client/src/hooks/useTest.ts
+++ b/client/src/hooks/useTest.ts
@@ -1,0 +1,89 @@
+import { UserContext } from "@/context/UserContext";
+import { API_URL } from "@/main";
+import { LogGroup } from "@/models/Log";
+import { useContext, useEffect, useState } from "react";
+
+function makeEventSource(
+  url: string,
+  onMessage: (logs: LogGroup[]) => void
+): EventSource {
+  const eventSource = new EventSource(url);
+
+  eventSource.onopen = () => console.log("[SSE] Connection established.");
+
+  eventSource.onmessage = (event) => {
+    const { message, status } = JSON.parse(event.data);
+
+    if (status === "close") {
+      console.log("[SSE] Connection closed.");
+      eventSource.close();
+    } else {
+      onMessage(message);
+    }
+  };
+
+  eventSource.onerror = (error) => {
+    console.error("[SSE] An error occured: ", error);
+    eventSource.close();
+  };
+
+  return eventSource;
+}
+
+export function useTest(fileId: string, onMessage: (logs: LogGroup[]) => void) {
+  const [eventSource, setEventSource] = useState<EventSource | null>(null);
+  const { token } = useContext(UserContext);
+
+  function run() {
+    if (eventSource) eventSource.close();
+
+    setEventSource(
+      makeEventSource(
+        `${API_URL}/api/tests/${fileId}/run?token=${token}`,
+        onMessage
+      )
+    );
+  }
+
+  function rerun(runId: string) {
+    if (eventSource) eventSource.close();
+
+    setEventSource(
+      makeEventSource(
+        `${API_URL}/api/runs/${runId}/compiled/run?token=${token}`,
+        onMessage
+      )
+    );
+  }
+
+  // Try to reconnect to an existing test
+  useEffect(() => {
+    const cleanup = async () => {
+      try {
+        await fetch(`${API_URL}/api/tests/${fileId}/cleanup`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ fileId }),
+        });
+        console.log(`[SSE] Server resources cleaned up for file: ${fileId}`);
+      } catch (err) {
+        console.error("[SSE] Error cleaning up server resources: ", err);
+      }
+    };
+
+    setEventSource(
+      makeEventSource(
+        `${API_URL}/api/tests/${fileId}/reconnect?token=${token}`,
+        onMessage
+      )
+    );
+
+    return () => {
+      cleanup();
+    };
+  }, [fileId, token, onMessage]);
+
+  return { run, rerun };
+}

--- a/client/src/screens/EditorScreen.tsx
+++ b/client/src/screens/EditorScreen.tsx
@@ -1,213 +1,25 @@
-import Editor from "@/components/Editor";
-import { Toaster } from "@/shadcn/components/ui/toaster";
-
-import { useCallback, useContext, useEffect, useState } from "react";
-
 import Menu from "@/components/Menu";
+import Editor from "@/components/Editor";
+import { useCallback, useState } from "react";
+import { Toaster } from "@/shadcn/components/ui/toaster";
 import { MainContext } from "@/context/MainContext";
 import { useParams } from "react-router";
-import { useToast } from "@/shadcn/hooks/use-toast";
-import { generateCode } from "@/utils/generateCode";
 import { Test } from "@/models/Statement";
-import { parseCode } from "@/utils/parseCode";
-import { UserContext } from "@/context/UserContext";
-import { API_URL } from "@/main";
 import { LogGroup } from "@/models/Log";
-import { TestFile } from "@/models/TestFile";
+import { useTest } from "@/hooks/useTest";
 
 function EditorScreen() {
   const { testId } = useParams();
-  const { toast } = useToast();
-
-  const { token } = useContext(UserContext);
 
   const [logs, setLogs] = useState<LogGroup[]>([]);
-
   const [fileId, setFileId] = useState<string>(testId!);
   const [code, setCode] = useState<string>("");
   const [isCode, setIsCode] = useState<boolean>(true);
   const [tests, setTests] = useState<Test[]>([]);
 
-  const [eventSource, setEventSource] = useState<EventSource | null>(null);
+  const onMessage = useCallback((logs: LogGroup[]) => setLogs(logs), []);
 
-  async function runTest(url: string) {
-    setLogs([]);
-
-    if (eventSource) {
-      eventSource.close();
-      console.log("Previous SSE connection closed.");
-    }
-
-    const newEventSource = new EventSource(`${url}?token=${token}`);
-    setEventSource(newEventSource);
-
-    newEventSource.onopen = () => {
-      console.log("SSE connection established.");
-    };
-
-    newEventSource.onmessage = (event) => {
-      const data = JSON.parse(event.data);
-      console.log(data);
-      const message = data.message;
-      const status = data.status;
-
-      console.log(message);
-      console.log(status);
-
-      if (status === "close") {
-        console.log("Gracefully stopping...");
-        newEventSource.close();
-      } else {
-        setLogs(message);
-      }
-    };
-
-    newEventSource.onerror = (error) => {
-      console.error("SSE error: ", error);
-      newEventSource.close();
-    };
-
-    return eventSource;
-  }
-
-  const saveDocument = useCallback(
-    async function (code: string, fileId: string) {
-      const res = await fetch(`${API_URL}/api/tests/${fileId}`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({
-          fileName: fileId, // TODO: FIX
-          content: code,
-        }),
-      });
-
-      if (!res.ok) {
-        toast({
-          title: "File with this name already exists",
-        });
-        return;
-      }
-      const file: TestFile = await res.json();
-      setFileId(file.id);
-      setCode(code);
-      toast({
-        title: "Saved successfully!",
-      });
-    },
-    [toast, token]
-  );
-
-  const handleSave = useCallback(
-    async function (fileId: string) {
-      if (isCode) {
-        await saveDocument(code, fileId);
-      } else {
-        const generatedCode = generateCode(tests);
-        const [, status] = parseCode(generatedCode);
-        if (status) {
-          setCode(generatedCode);
-          await saveDocument(generatedCode, fileId);
-        } else {
-          toast({
-            title: "Test syntax error!",
-            description:
-              "Please make sure you have filled out all the fields correctly then try again. Your progress is unsaved.",
-            variant: "destructive",
-          });
-        }
-      }
-    },
-    [code, isCode, saveDocument, tests, toast]
-  );
-
-  const reconnect = (fileId: string) => {
-    console.log("Reconnecting...");
-
-    if (eventSource) {
-      eventSource.close();
-    }
-
-    const url = `${API_URL}/api/tests/${fileId}/reconnect?token=${token}`;
-    const newEventSource = new EventSource(url);
-    setEventSource(newEventSource);
-
-    newEventSource.onopen = () => {
-      console.log("Reconnected to running tests.");
-    };
-
-    newEventSource.onmessage = (event) => {
-      const data = JSON.parse(event.data);
-      const message = data.message;
-      const status = data.status;
-
-      console.log(message);
-      console.log(status);
-
-      if (status === "close") {
-        console.log("Gracefully stopping...");
-        newEventSource.close();
-      } else {
-        setLogs(message);
-      }
-    };
-
-    newEventSource.onerror = (err) => {
-      console.error("Error with EventSource: ", err);
-      newEventSource.close();
-    };
-  };
-
-  const cleanup = async (fileId: string) => {
-    if (eventSource) {
-      eventSource.close();
-    }
-    try {
-      const url = `${API_URL}/api/tests/${fileId}/cleanup`;
-      await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ fileId }),
-      });
-      console.log(`Server resources cleaned up for file: ${fileId}`);
-    } catch (err) {
-      console.error("Error cleaning up server resources: ", err);
-    }
-  };
-
-  // Handle save input
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
-        event.preventDefault();
-        handleSave(fileId);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [fileId, handleSave]);
-
-  // Reconnect if possible when mounted and close connection and cleanup on unmount
-  useEffect(() => {
-    if (fileId) {
-      reconnect(fileId);
-    }
-
-    return () => {
-      if (eventSource) {
-        eventSource.close();
-        console.log("SSE connection closed during cleanup.");
-      }
-      if (fileId) {
-        cleanup(fileId);
-      }
-    };
-  }, []);
+  const { run } = useTest(fileId, onMessage);
 
   return (
     <MainContext.Provider
@@ -223,10 +35,7 @@ function EditorScreen() {
       }}
     >
       <div className="h-screen w-screen flex flex-col gap-3 p-3">
-        <Menu
-          onRun={() => runTest(`${API_URL}/api/tests/${fileId}/run`)}
-          onSave={handleSave}
-        />
+        <Menu onRun={run} />
         <Editor logs={logs} />
         <Toaster />
       </div>

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -1,7 +1,29 @@
-import Files from "@/components/Files";
+import FilesTable from "@/components/FilesTable";
+import { UserContext } from "@/context/UserContext";
+import { API_URL } from "@/main";
+import { TestFile } from "@/models/TestFile";
+import { useQuery } from "@tanstack/react-query";
+import { useContext } from "react";
+
+function useTests() {
+  const { token } = useContext(UserContext);
+  return useQuery<TestFile[]>({
+    queryKey: ["tests"],
+    queryFn: async () => {
+      const res = await fetch(`${API_URL}/api/tests`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      return await res.json();
+    },
+  });
+}
 
 function HomeScreen() {
-  return <Files />;
+  const { data: tests, isLoading } = useTests();
+
+  return isLoading ? <h1>Loading...</h1> : <FilesTable tests={tests!} />;
 }
 
 export default HomeScreen;

--- a/client/src/screens/RunsScreen.tsx
+++ b/client/src/screens/RunsScreen.tsx
@@ -5,11 +5,10 @@ import { TestFile } from "@/models/TestFile";
 import { TestRun } from "@/models/TestRun";
 import { Loader2Icon } from "lucide-react";
 import { useContext, useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router";
+import { useParams } from "react-router";
 
 function RunsScreen() {
   const { testId } = useParams();
-  const navigate = useNavigate();
 
   const { token } = useContext(UserContext);
   const [testRuns, setTestRuns] = useState<TestRun[]>([]);
@@ -57,14 +56,7 @@ function RunsScreen() {
       ) : (
         <h1 className="font-bold text-3xl">{testFile.name}</h1>
       )}
-      <TestRunTable
-        testRuns={testRuns}
-        onRerun={(run) => {
-          navigate(`/runs/${run.id}?execute=true`, {
-            state: run,
-          });
-        }}
-      />
+      <TestRunTable testRuns={testRuns} testId={testId!} />
     </div>
   );
 }

--- a/client/src/screens/ViewRunScreen.tsx
+++ b/client/src/screens/ViewRunScreen.tsx
@@ -1,109 +1,67 @@
 import ReadOnlyEditor from "@/components/ReadOnlyEditor";
 import { UserContext } from "@/context/UserContext";
+import { useTest } from "@/hooks/useTest";
 import { API_URL } from "@/main";
 import { LogGroup } from "@/models/Log";
 import { TestRun } from "@/models/TestRun";
 import { Button } from "@/shadcn/components/ui/button";
-import { ChevronLeft } from "lucide-react";
-import { useContext, useEffect, useState } from "react";
-import {
-  useLocation,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronLeft, RefreshCcw } from "lucide-react";
+import { useCallback, useContext, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router";
 
-function ViewRunScreen() {
-  const { runId } = useParams();
-
-  const [searchParams] = useSearchParams();
-
-  const executeParam = searchParams.get("execute");
-
-  const execute: boolean = new Boolean(executeParam).valueOf();
-
+function useLogs(runId: string) {
   const { token } = useContext(UserContext);
-  const { state } = useLocation();
-  const navigate = useNavigate();
-  const testRun: TestRun = state;
-
-  const [logs, setLogs] = useState<LogGroup[]>([]);
-  const [eventSource, setEventSource] = useState<EventSource | null>(null);
-
-  async function getLogs(token: string) {
-    try {
+  return useQuery<LogGroup[]>({
+    queryKey: ["logs"],
+    queryFn: async () => {
       const res = await fetch(`${API_URL}/api/runs/${runId}/logs`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       });
-      const logs: LogGroup[] = await res.json();
-      console.log(logs);
-      setLogs(logs);
-    } catch (err) {
-      console.log(err);
-    }
-  }
+      return await res.json();
+    },
+  });
+}
 
-  async function runTest(url: string) {
-    setLogs([]);
+function ViewRunScreen() {
+  const { runId, testId } = useParams();
 
-    if (eventSource) {
-      eventSource.close();
-      console.log("Previous SSE connection closed.");
-    }
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const testRun: TestRun = state;
 
-    const newEventSource = new EventSource(`${url}?token=${token}`);
-    setEventSource(newEventSource);
+  const { data, isLoading } = useLogs(runId!);
+  const [logs, setLogs] = useState<LogGroup[]>(data ?? []);
 
-    newEventSource.onopen = () => {
-      console.log("SSE connection established.");
-    };
-
-    newEventSource.onmessage = (event) => {
-      const data = JSON.parse(event.data);
-      console.log(data);
-      const message = data.message;
-      const status = data.status;
-
-      console.log(message);
-      console.log(status);
-
-      if (status === "close") {
-        console.log("Gracefully stopping...");
-        newEventSource.close();
-      } else {
-        setLogs(message);
-      }
-    };
-
-    newEventSource.onerror = (error) => {
-      console.error("SSE error: ", error);
-      newEventSource.close();
-    };
-
-    return eventSource;
-  }
-
-  useEffect(() => {
-    if (token) getLogs(token);
-  }, [token]);
-
-  useEffect(() => {
-    if (execute) runTest(`${API_URL}/api/runs/${runId}/compiled/run`);
-  }, [execute]);
+  const onMessage = useCallback((logs: LogGroup[]) => setLogs(logs), []);
+  const { rerun } = useTest(testId!, onMessage);
 
   return (
     <div className="h-screen w-screen p-5">
-      <Button
-        className="flex flex-row gap-3"
-        onClick={() => navigate("/")}
-        variant="link"
-      >
-        <ChevronLeft />
-        <h1>Back</h1>
-      </Button>
-      <ReadOnlyEditor code={testRun.rawCode} logs={logs} />
+      <div className="flex flex-row justify-between">
+        <Button
+          className="flex flex-row gap-3"
+          onClick={() => navigate(-1)}
+          variant="link"
+        >
+          <ChevronLeft />
+          <h1>Back</h1>
+        </Button>
+        <Button
+          className="flex flex-row gap-3"
+          variant="ghost"
+          onClick={() => rerun(runId!)}
+        >
+          <RefreshCcw /> Replay test
+        </Button>
+      </div>
+      {isLoading ? (
+        <h1>Loading...</h1>
+      ) : (
+        <ReadOnlyEditor code={testRun.rawCode} logs={logs} />
+      )}
     </div>
   );
 }

--- a/client/src/utils/sortHeader.tsx
+++ b/client/src/utils/sortHeader.tsx
@@ -1,0 +1,16 @@
+import { Button } from "@/shadcn/components/ui/button";
+import { Column } from "@tanstack/react-table";
+import { ArrowUpDown } from "lucide-react";
+
+export function sortHeader<T>(name: string) {
+  return ({ column }: { column: Column<T, unknown> }) => (
+    <Button
+      variant="ghost"
+      className="p-0 hover:bg-transparent"
+      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+    >
+      {name}
+      <ArrowUpDown className="ml-2 h-4 w-4" />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Description

This PR introduces major changes regarding how network requests are made inside the React app.

These changes include:

- Experimenting with `@tanstack/react-query` for traditional data fetching
- Implemented hooks to maintain test execution. 
   - `useTest` which exposes the `run` and `rerun` functions to be called by the component. This hook automatically handles reconnecting to existing tests on mount and cleanup on exit.
   - `useSave` which exposes the `saveDocument` function, to extract the saving logic from the components. This greatly enhances maintainability.
   - `useShortcut` is a utility hook which registers event listeners for `Ctrl/Cmd + S` to save and `Ctrl/Cmd + E` to run/execute.

Overall, this PR aims to simplify the code structure, making it easier to maintain the code from bugs and extend it with new features in the future.