### PR TITLE
fix: Add support for compiler CLI instead of DLL

### DIFF
--- a/api/Services/Test/TestExecutionService.cs
+++ b/api/Services/Test/TestExecutionService.cs
@@ -18,16 +18,17 @@ public class TestExecutionService(
 {
     public async Task RunTestAsync(TestFile testFile, string token)
     {
-        var (code, errors) = Parser.Parse(testFile.Content);
+        var (code, errors) = await Parser.Parse(testFile.Content);
         var group = new LogGroup
         {
             TestName = "Compiled succesfully",
             Status = LogStatus.FINISHED,
         };
 
-        if (errors.Length > 0)
+        if (errors.Count > 0)
         {
-            group.TestName = "Could not compile test file";
+            group.TestName = errors.Last();
+            errors.RemoveAt(errors.Count - 1);
 
             foreach (string err in errors)
                 group.Assertions.Add(new Assertion


### PR DESCRIPTION
## Description

In compliance with https://github.com/Ghaadyy/restricted-nl/commit/41f7a4cb4c7deecc5c78be97ddd9e13c046638f9, we were able to fix #30. The compiler now supports parsing input from standard input and returns the compiled code to standard out if no CLI parameters are passed.

## Related issues

Closes #30.