### PR TITLE
fix: Test execution with containers and Selenium Grid

### DIFF
--- a/api/Compiler/Parser.cs
+++ b/api/Compiler/Parser.cs
@@ -84,7 +84,7 @@ public static class Parser
         }}
 
         async function beforeHook() {{
-            socket = new WebSocket('ws://localhost:5064/ws/selenium?processId={processId}');
+            socket = new WebSocket('ws://host.docker.internal:5064/ws/selenium?processId={processId}');
             socket.onopen = async function () {{
                 console.log('open');
             }};

--- a/api/Services/Test/Dockerfile
+++ b/api/Services/Test/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22.11.0
+
+WORKDIR /app
+
+RUN npm install websocket selenium-webdriver && npm install -g mocha
+
+ENV SELENIUM_REMOTE_URL=http://host.docker.internal:4444/wd/hub
+
+CMD ["bash"]

--- a/api/Services/Test/TestExecutionService.cs
+++ b/api/Services/Test/TestExecutionService.cs
@@ -105,6 +105,7 @@ public class TestExecutionService(
             CreateNoWindow = true,
         };
 
+        stopwatch.Start();
         using var process = Process.Start(dockerInfo);
         if (process is null)
         {
@@ -117,6 +118,7 @@ public class TestExecutionService(
             return (false, 0);
         }
         await process.WaitForExitAsync();
+        stopwatch.Stop();
 
         File.Delete(tempFilePath);
 


### PR DESCRIPTION
## Description

This PR introduces a simple yet important change. It is related to how and where the compiled scripts execute. Currently, we were creating a process which ran on the same machine of the ASP.NET API, and forced us to install npm dependencies each time a test is executed. This consumed a lot of time during development and does not scale for production.

## Solution

Instead of creating a bare process on the machine, we create a process which instantiates a Docker container. This container is prebuilt by the developer and gets stored on their machine. This way, the environment for the test is always ready, we just have to call `docker run` to spin a running instance. This simple change greatly boosts the test execution speed and simplifies process management in the `TestExecutionService`. 

However, to achieve complete functionality as before, the container has to communicate with the browser. Thankfully, [Selenium Grid](https://www.selenium.dev/documentation/grid/) provides us with a server that will allow us to have a remote web driver instead of a local one.

- The `Dockerfile` of the provided test execution image is provided in `api/Services/Test`
- In order to develop with this new change, you need to have a Selenium Grid installation (and spin an instance with `java -jar selenium-server-4.28.1.jar standalone`).

## Related issues

Closes #5.