### PR TITLE
fix: Fixed authorization in SSE endpoints

### DIFF
--- a/api/Controllers/UsersController.cs
+++ b/api/Controllers/UsersController.cs
@@ -34,10 +34,10 @@ public class UsersController(
     [HttpGet("me")]
     public ActionResult<User> GetUserInfo()
     {
-        var userId = tokenService.GetId(User);
-        if (userId is null) return BadRequest("User ID missing from token");
+        var id = tokenService.GetId(User);
+        if (id is null) return BadRequest("User ID missing from token");
 
-        User? user = userRepository.GetUserById(userId.Value);
+        User? user = userRepository.GetUserById(id.Value);
         if (user is null) return NotFound("User not found");
 
         return Ok(user);
@@ -89,10 +89,10 @@ public class UsersController(
     [HttpPatch]
     public async Task<ActionResult<User>> Update([FromBody] JsonPatchDocument<User> patchDoc)
     {
-        var userId = tokenService.GetId(User);
-        if (userId is null) return BadRequest("User ID missing from token");
+        var id = tokenService.GetId(User);
+        if (id is null) return BadRequest("User ID missing from token");
 
-        User? user = userRepository.GetUserById(userId.Value);
+        User? user = userRepository.GetUserById(id.Value);
         if (user is null) return NotFound("Invalid user id.");
 
         patchDoc.ApplyTo(user);
@@ -111,10 +111,10 @@ public class UsersController(
 
     public async Task<ActionResult<User>> Delete()
     {
-        var userId = tokenService.GetId(User);
-        if (userId is null) return BadRequest("User ID missing from token");
+        var id = tokenService.GetId(User);
+        if (id is null) return BadRequest("User ID missing from token");
 
-        User? user = userRepository.GetUserById(userId.Value);
+        User? user = userRepository.GetUserById(id.Value);
         if (user is null) return NotFound("Invalid user id.");
 
         await userRepository.DeleteUser(user);

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -10,6 +10,7 @@ using RestrictedNL.Services.Token;
 using RestrictedNL.Repository.User;
 using RestrictedNL.Services.Http;
 using RestrictedNL.Services.Test;
+using RestrictedNL.Services.Compiler;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,6 +23,8 @@ builder.Services.AddCors();
 
 builder.Services.AddControllers().AddNewtonsoftJson();
 
+builder.Services.AddHttpContextAccessor();
+
 // Register repositories
 builder.Services.AddScoped<ITestRepository, TestRepository>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
@@ -32,6 +35,7 @@ builder.Services.AddScoped<TestExecutionService>();
 builder.Services.AddScoped<RedisLogService>();
 builder.Services.AddScoped<RedisProcessService>();
 builder.Services.AddSingleton<HttpService>();
+builder.Services.AddSingleton<CompilerService>();
 
 builder.Services.AddDbContext<TestContext>(options =>
 {

--- a/api/Services/Compiler/CompilerService.cs
+++ b/api/Services/Compiler/CompilerService.cs
@@ -1,11 +1,14 @@
 using System.Diagnostics;
 using System.Text;
 
-namespace RestrictedNL.Compiler;
+namespace RestrictedNL.Services.Compiler;
 
-public static class Parser
+public class CompilerService(
+    IConfiguration configuration,
+    IHttpContextAccessor accessor
+    )
 {
-    public static async Task<(string code, List<string> errors)> Parse(string code)
+    public async Task<(string code, List<string> errors)> Parse(string code)
     {
         var compInfo = new ProcessStartInfo
         {
@@ -43,8 +46,11 @@ public static class Parser
         return (compiledCode, errors.ToList());
     }
 
-    public static string ConfigureSeeClick(string code, string token, string url)
+    public string ConfigureSeeClick(string code)
     {
+        string url = configuration["ConnectionStrings:SeeClick"]!;
+        string token = accessor.HttpContext?.Request.Headers.Authorization.FirstOrDefault()?.Split(" ").Last()!;
+
         StringBuilder sb = new();
 
         sb.Append(Environment.NewLine);
@@ -62,7 +68,7 @@ public static class Parser
         return sb.ToString();
     }
 
-    public static string WrapWithSockets(string code, Guid processId)
+    public string ConfigureSockets(string code, Guid processId)
     {
         StringBuilder sb = new();
 

--- a/api/Services/Http/HttpService.cs
+++ b/api/Services/Http/HttpService.cs
@@ -18,13 +18,7 @@ public class HttpService
     public HttpResponse? Get(Guid userId, Guid fileId)
     {
         LogKey key = new(userId, fileId);
-
-        if (ActiveConnections.TryGetValue(key, out var response))
-        {
-            return response;
-        }
-
-        return null;
+        return ActiveConnections.GetValueOrDefault(key);
     }
 
     public void Remove(Guid userId, Guid fileId)
@@ -48,11 +42,9 @@ public class HttpService
                 ContractResolver = new CamelCasePropertyNamesContractResolver()
             });
 
-            var data = $"data: {sseObject}\n\n";
+            await response.WriteAsync(sseObject);
 
-            await response.WriteAsync(data);
-
-            Console.WriteLine(data);
+            Console.WriteLine(sseObject);
 
             await response.Body.FlushAsync();
         }


### PR DESCRIPTION
## Description

Authorization for SSE endpoints were handled manually. It is better to let the framework handle this.
This change introduces `Authorize` attributes to these endpoints and use manual streaming inside the `useTest` hook instead of using `EventSource` which was the initial reason why we couldn't pass Authorization headers with the request.

- Additional refactoring has been made inside the controllers to benefit from this change.